### PR TITLE
Add the typescript module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
   - rustc --version
   # Install Shellcheck on OSX
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install shellcheck; fi
+  - npm i -g typescript
 
 before_script:
   - export PATH="$(pwd):$PATH"

--- a/config
+++ b/config
@@ -10,13 +10,14 @@ TMP="/tmp"
 ## RUNTIMES
 NODE="node"
 RUBY="ruby"
-PYTHON="python"
+PYTHON="python3"
 
 ## COMPILERS
 CPP_COMPILER="g++"
 C_COMPILER="gcc"
 RUST_COMPILER="rustc"
 JAVA_COMPILER="javac"
+TYPESCRIPT_COMPILER="tsc"
 
 ### WARNING: Data below this line is for REPL use only.
 ### Edit only if you know what you're doing.

--- a/config.default
+++ b/config.default
@@ -10,13 +10,14 @@ TMP="/tmp"
 ## RUNTIMES
 NODE="node"
 RUBY="ruby"
-PYTHON="python"
+PYTHON="python3"
 
 ## COMPILERS
 CPP_COMPILER="g++"
 C_COMPILER="gcc"
 RUST_COMPILER="rustc"
 JAVA_COMPILER="javac"
+TYPESCRIPT_COMPILER="tsc"
 
 ### WARNING: Data below this line is for REPL use only.
 ### Edit only if you know what you're doing.

--- a/language_support.sh
+++ b/language_support.sh
@@ -10,4 +10,5 @@ declare -a LANGUAGES=(
   "py"
   "rb"
   "rs"
+  "ts"
 )

--- a/repl_modules.sh
+++ b/repl_modules.sh
@@ -1,7 +1,6 @@
 # shellcheck shell=bash
 
 # Modules are listed in alphabetical order
-
 # Modules with boilerplate code MUST print EXACTLY "Hello world!" to the console
 
 # TODO: Exit if the runtime/compiler is not found
@@ -137,6 +136,25 @@ repl_rs() {
     cd "${TMP}" && \
       "$RUST_COMPILER" "repl.rs" && \
       ./repl
+    ;;
+  esac
+}
+
+repl_ts() {
+  case "$1" in
+  edit)
+    if [ ! -e "$2" ]; then
+      cd "${TMP}" && \
+        touch "repl.ts" && \
+        {
+          printf 'console.log("Hello world!");\n'
+        } >> "repl.ts"
+    fi
+    ;;
+  run)
+    cd "${TMP}" && \
+      "$TYPESCRIPT_COMPILER" "repl.ts" && \
+      $NODE "repl.js"
     ;;
   esac
 }

--- a/test/modules_test.sh
+++ b/test/modules_test.sh
@@ -84,4 +84,11 @@ test_rs_module() {
   assert_repl_run
 }
 
+test_ts_module() {
+  repl_command ts
+  assertContains "$(ls repl_tmp/)" "repl.ts"
+
+  assert_repl_run
+}
+
 . "./test/libs/shunit2/shunit2"


### PR DESCRIPTION
- Add support for TypeScript
- Update the default python runtime to `python3`

__Note for Hacktoberfest participants__
Do not worry about updating the `.travis.yml` file. The plan is to switch to Github actions (another idea for contributors? 😉)