### PR TITLE
Adds `Repl Languages` command to list all supported languages; Update missing language in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ If time passes and you forget which repl you are on, simply run:
 repl status
 ```
 
+To list the currently supported languages, run:
+
+```
+repl languages
+```
+
 Check out our list of [supported languages](#supported-languages), and their file extensions, below.
 
 ## Configuring REPL
@@ -113,6 +119,7 @@ If you break the config file and you're not sure how to fix it, you can copy the
 - Python (`py`)
 - Ruby (`rb`)
 - Rust (`rs`)
+- Typescript (`ts`)
 
 <sub>You must have the necessary compilers/runtimes installed (e.g., `node.js` for JavaScript or `rustc` for Rust). Edit the `config` file to configure the compilers/runtimes that REPL uses.</sub>
 

--- a/bin/repl
+++ b/bin/repl
@@ -49,6 +49,10 @@ repl_config() {
   esac
 }
 
+repl_languages() {
+  echo "repl: Currently supports - ${LANGUAGES[*]}"
+}
+
 repl_edit() {
   for lang in "${LANGUAGES[@]}"; do
     if [ "$EXT" = "$lang" ]; then
@@ -109,6 +113,9 @@ main() {
     ;;
   status)
     repl_status
+    ;;
+  languages)
+    repl_languages
     ;;
   config)
     if [ -n "$PARAM1" ] && [ -n "$PARAM2" ]; then

--- a/bin/repl
+++ b/bin/repl
@@ -50,7 +50,11 @@ repl_config() {
 }
 
 repl_languages() {
-  echo "repl: Currently supports - ${LANGUAGES[*]}"
+  echo "repl: Supported languages"
+  for language in "${LANGUAGES[@]}"
+  do
+    echo "- $language"
+  done
 }
 
 repl_edit() {

--- a/test/main_test.sh
+++ b/test/main_test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+. "./language_support.sh"
 
 . "./test/test_helper.sh"
 
@@ -35,6 +36,13 @@ test_status() {
   status=$(./bin/repl status)
 
   assertContains "Should display the correct status message for the current repl" "$status" "status: currently in a js repl"
+}
+
+test_languages() {
+  local languages
+  languages=$(./bin/repl languages)
+
+  assertEquals "repl: Currently supports - ${LANGUAGES[*]}" "$languages"
 }
 
 test_edit() {

--- a/test/main_test.sh
+++ b/test/main_test.sh
@@ -42,7 +42,10 @@ test_languages() {
   local languages
   languages=$(./bin/repl languages)
 
-  assertEquals "repl: Currently supports - ${LANGUAGES[*]}" "$languages"
+  for language in "${LANGUAGES[@]}"
+  do
+    assertContains "$languages" "$language"
+  done
 }
 
 test_edit() {


### PR DESCRIPTION
Hello @DamianRivas!👋

This PR has the following changes
- Adds `Repl Languages` command to list all supported languages
- Updates Readme's supported languages list with `TS`   